### PR TITLE
Switch to endpoint version 2

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -34,12 +34,13 @@ export default {
     }
   },
   mounted() {
-    axios.get("https://rki-vaccination-data.vercel.app/api").then(data => {
+    axios.get("https://rki-vaccination-data.vercel.app/api/v2").then(data => {
       let impfStart = new Date("2020-12-27T00:00:00")
       let lastUpdateDate = new Date(data.data.lastUpdate)
       let diffDays = Math.round((lastUpdateDate.getTime() - impfStart.getTime()) / (1000*3600*24))
       let daysSinceStart = Math.round((Date.now() - impfStart.getTime()) / (1000*3600*24))
-      let quote = data.data.quote;
+      let countryData = data.data.data.find(e => e.name == 'Deutschland');
+      let quote = countryData.vaccinatedAtLeastOnce.quote;
       let daysRemaining = Math.round((diffDays / quote * 100) - daysSinceStart)
       this.yearsRemaining = Math.floor(daysRemaining/365)
       this.daysRemaining = daysRemaining - (this.yearsRemaining*365)


### PR DESCRIPTION
Since the `/api` endpoint now shows a deprecation notice, it may be a good idea to switch to the suggested newer version.

As far as I could see, the only two pieces of information that are used are the last update time and the total quote of first vaccinations.
The position of the last update time did not change.
The data for the whole country is now in an array together with all the states. As I don't want to rely on the assumption that it will always be the last element of that array, we have to search for the element with the correct name.

I don't have a development environment for Vue.js, so I could only test the changes by modifying the compiled code.
With the usage of `find()` to search for the country element, it won't work for the more adventurous people using Internet Explorer, but maybe Vue.js will replace that with a polyfill during compilation. If it doesn't and it's an issue for you, this call can be replaced by `filter()[0]`, which would make it at least compatible to IE 9 and above. However, the fearless folks browsing the web with Windows XP and Internet Explorer 8 probably still won't see the vaccination estimation with that solution (according to MDN).